### PR TITLE
Priority card links/prop types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,7 +2871,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3236,7 +3237,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3284,6 +3286,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3322,11 +3325,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6875,7 +6880,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7240,7 +7246,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7288,6 +7295,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7326,11 +7334,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "node-sass": "^4.12.0",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.1",

--- a/src/components/ActionsPage.js
+++ b/src/components/ActionsPage.js
@@ -22,22 +22,22 @@ const Header = styled.div`
 `;
 
 export default class ActionPage extends Component {
-  
+
   share = () => {
     var url = "http://google.com";
     var text = "Replace this with your text";
-    window.open('http://twitter.com/share?url='+encodeURIComponent(url)+'&text='+encodeURIComponent(text), '', 'left=0,top=0,width=550,height=450,personalbar=0,toolbar=0,scrollbars=0,resizable=0');
+    window.open('http://twitter.com/share?url=' + encodeURIComponent(url) + '&text=' + encodeURIComponent(text), '', 'left=0,top=0,width=550,height=450,personalbar=0,toolbar=0,scrollbars=0,resizable=0');
   }
 
   render() {
     return (
       <ActionStyled>
         <Header>
-          <img src={'an image'} />
+          <img src={'an image'} alt={'some alt text'} />
           <h2>Event Title</h2>
           <p>Event Author</p>
           <p>07/20/2019</p>
-          <button onClick={() => {this.share()}}> Share </button>
+          <button onClick={() => { this.share() }}> Share </button>
         </Header>
         <p>Some details of the page event.</p>
       </ActionStyled>

--- a/src/components/PrioritiesOrderPage.js
+++ b/src/components/PrioritiesOrderPage.js
@@ -1,5 +1,9 @@
 import React from "react";
 import PriorityCard from "./PriorityCard";
+import Header from './Header';
+import LocationHolder from "./LocationHolder";
+
+import edit from "../assets/edit.svg";
 
 export default class PrioritiesOrderPage extends React.Component {
   // DUMMY DATA //
@@ -69,14 +73,10 @@ export default class PrioritiesOrderPage extends React.Component {
     let sortedData = [...this.state.priorities].sort((a, b) => (a.rank > b.rank ? 1 : -1));
     return (
       <div>
-        <h1>Edit Priorities</h1>
+        <Header title={"Priorities"} optionIcon={edit} option={"/editPriorities"} optionName={"Edit Priorities"} />
+        <LocationHolder hood={"neighborhood"} />
         <div>
-          <h2>Add New Priority</h2>
-          <p>Noticed something new in your comunity?</p>
-        </div>
-        <div>
-          <h2>Rearrange Priorities</h2>
-          <p>Change the priority order by selecting the arrows.</p>
+          <h2 style={{ color: '#6A81AC' }}>Rearrange Priorities</h2>
           <ul>
             {sortedData.map((priority, index) => {
               return (

--- a/src/components/PriorityCard.js
+++ b/src/components/PriorityCard.js
@@ -1,31 +1,58 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Redirect } from "react-router-dom";
 import blackArrow from '../assets/chevron-right-black.svg';
+import PropTypes from 'prop-types';
+// const PriorityCard = ({ rank, type, description, promote, demote, location }) => {
+const buttonStyle = {
+  height: '25px', width: '100px', backgroundColor: '#6A81AC', color: 'white', borderRadius: '25px', border: '1px solid #6A81AC', margin: '0 1rem'
+};
+class PriorityCard extends React.Component {
+  state = {
+    redirect: false,
+    reRoute: '/',
+  }
 
-const PriorityCard = ({ rank, type, description, promote, demote, location }) => {
-  return (
-    <div className="priorityCard">
-      <div className="priorityCard__banner">
-        <p>#{rank} Priority</p>
-        <p>{location}</p>
-      </div>
-      <div className="priorityCard__overview">
-        <h2 className="heading-tertiary">{type}</h2>
-        <p className="descriptions">{description}</p>
-      </div>
-      {(location === '/editPriorities') && (
-        <div style={{ margin: '1rem' }}>
-          <button onClick={() => { promote() }} style={{ height: '15px', width: '60px' }}>^</button>
-          <button onClick={() => { demote() }} style={{ height: '15px', width: '60px' }}>V</button>
+  navToPriority = () => {
+    if (window.event.target.id !== 'promote' && window.event.target.id !== 'demote') {
+      this.setState({
+        redirect: true,
+        reRoute: ''
+      });
+    }
+  }
+
+  render() {
+    const { rank, type, description, promote, demote, location } = this.props; //needs priorityId
+    if (this.state.redirect) return <Redirect to={`/${this.state.reRoute}`} />;
+    return (
+      <div className="priorityCard" onClick={() => { this.navToPriority(type) }} style={{ display: 'block' }}>
+        <div className="priorityCard__banner">
+          <p>#{rank} Priority</p>
+          <p>{type}</p>
         </div>
-      )}
-      <Link to="/priorityDetails">
+        <div className="priorityCard__overview">
+          <h2 className="heading-tertiary">{type}</h2>
+          <p className="descriptions">{description}</p>
+        </div>
+        {(location === '/editPriorities') && (
+          <div style={{ margin: '1rem' }}>
+            <button id="promote" onClick={() => { promote() }} style={buttonStyle}>Promote Priority</button>
+            <button id="demote" onClick={() => { demote() }} style={buttonStyle}>Demote Priority</button>
+          </div>
+        )}
         <img className="priorityCard__image chevronArrow" src={blackArrow} alt="arrow" />
-      </Link>
-    </div>
-  );
+      </div>
+    );
+  }
 };
 
-PriorityCard.propTypes = {};
+PriorityCard.propTypes = { //needs a priorityId
+  rank: PropTypes.number,
+  type: PropTypes.string,
+  description: PropTypes.string,
+  promote: PropTypes.func,
+  demote: PropTypes.func,
+  location: PropTypes.string,
+};
 
 export default PriorityCard;

--- a/src/components/PriorityDetails.js
+++ b/src/components/PriorityDetails.js
@@ -1,14 +1,14 @@
 import React from "react";
 import Post from "./Post";
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
 import { seed, seed2 } from "./seed";
 import Header from "./Header";
 import edit from "../assets/edit.svg";
 
 //Test endpoints for GET requests
-const API_PAST = "https://nameless-garden-17654.herokuapp.com";
-const API_UPCOMING = "https://nameless-garden-17654.herokuapp.com";
-const API_ADD = "https://whimsical.com/32AqWM2AASAS7Ja6fqTp9a";
+// const API_PAST = "https://nameless-garden-17654.herokuapp.com";
+// const API_UPCOMING = "https://nameless-garden-17654.herokuapp.com";
+// const API_ADD = "https://whimsical.com/32AqWM2AASAS7Ja6fqTp9a";
 
 export default class PriorityDetails extends React.Component {
     constructor(props) {
@@ -99,13 +99,13 @@ export default class PriorityDetails extends React.Component {
             <div>
                 <Header title={"Priorities"} optionIcon={edit} option={"/addNewEvent"} optionName={"Add Event"} />
                 <div className="details">
-                <div>
-                    <h2 className="heading-secondary">Events</h2>
+                    <div>
+                        <h2 className="heading-secondary">Events</h2>
+                    </div>
+                    <button onClick={() => this.loadPast()}>Past Events</button>
+                    <button onClick={() => this.loadUpcoming()}>Upcoming Events</button>
+                    {formedData}
                 </div>
-                <button onClick={() => this.loadPast()}>Past Events</button>
-                <button onClick={() => this.loadUpcoming()}>Upcoming Events</button>
-                {formedData}
-            </div>
             </div>
         );
     }


### PR DESCRIPTION
I added prop-types for type checking incoming props as well as reworked the PriorityCards so that they will show buttons to change the priority *only*  when on the correct page and made it so the entire button is a link to (eventually) the particular priority.  It was like this previously, but adding the buttons to rearrange required refactoring so the buttons changed the order without redirecting to another page.

There are also some files that kept setting of linting rules so I commented out some things and added alt tags to images.