### PR TITLE
Fix app title and remove thisExpression warning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Neighborhood Connect</title>
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   </head>
   <body>

--- a/src/components/LinkToPage.js
+++ b/src/components/LinkToPage.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { thisExpression } from '@babel/types';
 
 export default class LinkToPage extends React.Component {
     render() {


### PR DESCRIPTION
Simple changes to clean up for the demo.
Change the page title, and remove a warning from an unused lib