### PR TITLE
add reroute back to entire card (not just chevron)

### DIFF
--- a/src/components/PriorityCard.js
+++ b/src/components/PriorityCard.js
@@ -26,21 +26,21 @@ class PriorityCard extends React.Component {
     if (this.state.redirect) return <Redirect to={`/actions/${this.state.reRoute}`} />;
 
     //render option based on route: nav to more details or re-rank priorities
-    let controlOption = location === "/editPriorities" ? 
-          <div className="priorityCard__control">
-            <button id="promote" onClick={() => { promote() }}><img className="chevronArrow" src={chevronup} alt="arrow" /></button>
-            <button id="demote" onClick={() => { demote() }}><img className="chevronArrow" src={chevrondown} alt="arrow" /></button>
-          </div>
-          :
-          <img className="priorityCard__image chevronArrow" onClick={() => { this.navToPriority(id) }} src={chevronright} alt="arrow" />;
+    let controlOption = location === "/editPriorities" ?
+      <div className="priorityCard__control">
+        <button id="promote" onClick={() => { promote() }}><img className="chevronArrow" src={chevronup} alt="arrow" /></button>
+        <button id="demote" onClick={() => { demote() }}><img className="chevronArrow" src={chevrondown} alt="arrow" /></button>
+      </div>
+      :
+      <img className="priorityCard__image chevronArrow" onClick={() => { this.navToPriority(id) }} src={chevronright} alt="arrow" />;
 
     return (
       <div className="priorityCard" style={this.props.style}>
-        <div className="priorityCard__banner">
+        <div className="priorityCard__banner" onClick={() => { this.navToPriority(id) }}>
           <p>#{rank} Priority</p>
           <p>{type}</p>
         </div>
-        <div className="priorityCard__overview">
+        <div className="priorityCard__overview" onClick={() => { this.navToPriority(id) }}>
           <h2 className="heading-tertiary">{type}</h2>
           <p className="descriptions">{description}</p>
         </div>


### PR DESCRIPTION
The refactor of the PriorityCard made only the chevron svg's act as a link to the priority/action, not the whole card.

This make the entire card forward to the priority/action and the chevrons act as buttons to change the priority order.