### PR TITLE
changed wording

### DIFF
--- a/src/components/ActionsPage.js
+++ b/src/components/ActionsPage.js
@@ -48,7 +48,7 @@ export default class ActionsPage extends Component {
             <div>
                 <Header title={"Actions"} option={`/newAction/${this.props.match.params.priorityId}`} optionName={"New Action"} optionIcon={action} />
                 <div className="details">
-                    <h2 className="heading-secondary u-margin-bottom-small">Future Events</h2>
+                    <h2 className="heading-secondary u-margin-bottom-small">Actions Taken</h2>
                     {actionsList}
                 </div>
             </div>


### PR DESCRIPTION
a fix for #85 - I clarified with @ryanmdoyle after not finding the working in the codebase that was named in the ticket.

test:
1) Navigate to http://localhost:3001/actions/46
2) Observe that the header is 'actions taken' instead of 'future events'
